### PR TITLE
WSS now handles sending request to right client instead of frontend

### DIFF
--- a/backend/controllers/endpoints.js
+++ b/backend/controllers/endpoints.js
@@ -40,7 +40,10 @@ module.exports = (wss) => {
   const sendNewRequestToClients = (wss, requestRow) => {
     if (wss.clients) {
       wss.clients.forEach((client) => {
-        client.send(JSON.stringify(requestRow));
+        // Only send to the appropriate clients
+        if (client.binPath == requestRow.bin_path) {
+          client.send(JSON.stringify(requestRow));
+        }
       });
     }
   }

--- a/backend/wsserver.js
+++ b/backend/wsserver.js
@@ -1,5 +1,6 @@
 const WebSocket = require('ws');
 const http = require('http');
+const url = require('url');
 const { v4: uuidv4 } = require('uuid');
 
 class WSServer {
@@ -21,9 +22,12 @@ class WSServer {
     });
   }
   
-  handleConnection(ws) {
-    const clientId = uuidv4();
-    console.log(`Client connected: ${clientId}`);
+  handleConnection(ws, req) {
+    const query = url.parse(req.url, true).query;
+    const binPath = query.binPath;
+
+    // Store bin path of client
+    ws.binPath = binPath;
     this.clients.add(ws)
 
     ws.on('message', this.handleMessageReceivedFromClient);

--- a/frontend/public/javascripts/bin.js
+++ b/frontend/public/javascripts/bin.js
@@ -37,15 +37,13 @@ const mapToRequests = (requests) => {
   return requests.map(request => new Request(request))
 };
 
-const connectToWSS = (binId) => {
-  const socket = new WebSocket('ws://localhost:3005');
+const connectToWSS = (binPath) => {
+  const socket = new WebSocket(`ws://localhost:3005?binPath=${binPath}`);
 
   socket.onmessage = (event) => {
     const requestData = JSON.parse(event.data);
-    if (requestData.bin_path === binId) {
-      // Render the new request
-      console.log("Received Request:", requestData);
-    }
+    // Render the new request
+    console.log("Received Request:", requestData);
   }
 
   socket.onerror = (error) => {


### PR DESCRIPTION
Send current bin_path to WSS server on WSS connect
WSS stores the bin_path for any given client

When a new request is received, it compares the bin_path of the new request with the bin path of each client, if the client is connected to that bin_path, it sends them the new request, if not, it continues iterating.